### PR TITLE
Make more generic solution to hpal flags via amendments

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -14,15 +14,22 @@ exports.create = (amendments, includeExtras) => {
         amendments = { add: amendments };
     }
 
-    const recursive = !!amendments.recursive;
-    const noUseStrictHeader = !!amendments.noUseStrictHeader;
-    const include = amendments.include;
-    const exclude = (include || amendments.exclude) ?
-        amendments.exclude :
+    let {
+        recursive,
+        include,
+        exclude,
+        add,
+        remove,
+        ...meta
+    } = amendments;
+
+    recursive = !!recursive;
+    exclude = (include || exclude) ? exclude :
         (filename, path) => path.split(Path.sep).includes('helpers');
 
-    const add = Hoek.flatten([].concat(amendments.add || [])); // Allow nested [{}, [{}]]
-    const remove = [].concat(amendments.remove || []);
+    add = Hoek.flatten([].concat(add || [])); // Allow nested [{}, [{}]]
+    remove = [].concat(remove || []);
+
     const toObject = (collect, value) => ({ ...collect, [value]: true });
     const addLookup = add.map(({ place }) => place).reduce(toObject, {});
     const removeLookup = remove.reduce(toObject, {});
@@ -47,7 +54,7 @@ exports.create = (amendments, includeExtras) => {
 
     return topoList.nodes.map((item) => {
 
-        item = Hoek.applyToDefaults({ recursive, noUseStrictHeader, include, exclude }, item);
+        item = Hoek.applyToDefaults({ recursive, include, exclude, meta }, item);
 
         if (!includeExtras) {
             delete item.before;

--- a/test/index.js
+++ b/test/index.js
@@ -524,9 +524,9 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
-                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
-                    include: Joi.func()
+                    include: Joi.func(),
+                    meta: Joi.object()
                 }));
 
                 const summarize = (item) => `${item.method}() at ${item.place}`;
@@ -568,12 +568,12 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
-                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
                     include: Joi.func(),
                     before: Joi.array().items(Joi.string()).single(),
                     after: Joi.array().items(Joi.string()).single(),
-                    example: Joi.any()
+                    example: Joi.any(),
+                    meta: Joi.object()
                 }));
 
                 const summarize = (item) => `${item.method}() at ${item.place}`;
@@ -651,7 +651,7 @@ describe('HauteCouture', () => {
                     place: 'routes',
                     method: 'myRoute',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -680,7 +680,7 @@ describe('HauteCouture', () => {
                     place: 'routes',
                     method: 'myRoute',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
 
                 const schwiftyItem = manifest.find((item) => item.place === 'models');
@@ -688,7 +688,7 @@ describe('HauteCouture', () => {
                     place: 'models',
                     method: 'mySchwifty',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -704,8 +704,7 @@ describe('HauteCouture', () => {
                         },
                         {
                             place: 'funky-bind',
-                            method: 'funkyBind',
-                            noUseStrictHeader: true
+                            method: 'funkyBind'
                         }
                     ]
                 })
@@ -723,14 +722,14 @@ describe('HauteCouture', () => {
                     place: 'funky-routes',
                     method: 'funkyRoutes',
                     recursive: true,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
 
                 expect(manifest[defaultLength + 1]).to.equal({
                     place: 'funky-bind',
                     method: 'funkyBind',
                     recursive: false,
-                    noUseStrictHeader: true
+                    meta: {}
                 });
             });
 
@@ -757,7 +756,7 @@ describe('HauteCouture', () => {
                     place: 'funky-routes',
                     method: 'funkyRoutes',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -803,6 +802,23 @@ describe('HauteCouture', () => {
 
                 expect(funkyIndex).to.be.above(indexOf('auth/strategies', manifest));
                 expect(funkyIndex).to.be.below(indexOf('auth/default', manifest));
+            });
+
+            it('passes through additional keys as meta on each item.', () => {
+
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
+                const manifest = HauteCouture.manifest.create({
+                    exampleUseStrict: false
+                })
+                    .map(ignoreFields);
+
+                expect(manifest.length).to.equal(defaultManifest.length);
+
+                defaultManifest.forEach((item, i) => {
+
+                    expect(item).to.not.equal(manifest[i]);
+                    expect({ ...item, meta: { exampleUseStrict: false } }).to.equal(manifest[i]);
+                });
             });
         });
     });


### PR DESCRIPTION
Here's my proposed change to https://github.com/hapipal/haute-couture/pull/50.  The idea is for hpal to depend on haute-couture, but not vice-versa.  Technically there's an unused key on these amendments named `meta` which we can use to put generic non-haute-couture-related stuff.  Now any additional, unrecognized keys in the manifest will be plopped into each item's `meta` key.  So hpal can look for flags that only it cares about in there.

Will this work for your purposes?  If so, the next steps will be to merge this then update https://github.com/hapipal/hpal/pull/24 to pull the flag off `item.meta`.  I also suggested a slightly different flag name `exampleUseStrict`, which hpal should assume defaults to `true` in its absence.